### PR TITLE
Implement Early Stopping

### DIFF
--- a/merf/merf.py
+++ b/merf/merf.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class MERF(object):
-    def __init__(self, n_estimators=300, min_iterations=10, gll_early_stop_threshold=1e-4, max_iterations=20):
+    def __init__(self, n_estimators=300, min_iterations=10, gll_early_stop_threshold=None, max_iterations=20):
         self.n_estimators = n_estimators
         self.min_iterations = min_iterations
         self.gll_early_stop_threshold = gll_early_stop_threshold
@@ -124,7 +124,9 @@ class MERF(object):
         self.sigma2_hat_history.append(sigma2_hat)
         self.D_hat_history.append(D_hat)
 
-        while iteration < self.max_iterations:
+        stop_flag, iter_begun = False, False
+
+        while iteration < self.max_iterations and not stop_flag:
             iteration += 1
             logger.debug("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
             logger.debug("Iteration: {}".format(iteration))
@@ -241,6 +243,18 @@ class MERF(object):
 
             logger.info("GLL is {} at iteration {}.".format(gll, iteration))
             self.gll_history.append(gll)
+
+            if self.gll_early_stop_threshold is not None:
+                if not iter_begun:
+                    iter_begun = True
+                else:
+                    curr_threshold = np.abs((gll - self.gll_history[-2]) / self.gll_history[-2])
+                    logger.debug("stop threshold = {}".format(curr_threshold))
+
+                    if curr_threshold < self.gll_early_stop_threshold:
+                        logger.info("Gll {} less than threshold {}, stopping early ...".
+                                    format(gll, curr_threshold))
+                        stop_flag = True
 
         # Store off most recent random forest model and b_hat as the model to be used in the prediction stage
         self.cluster_counts = cluster_counts

--- a/merf/tests.py
+++ b/merf/tests.py
@@ -86,6 +86,8 @@ class DataGenerationTest(unittest.TestCase):
 
 class MERFTest(unittest.TestCase):
     def setUp(self):
+        np.random.seed(3187)
+
         dg = MERFDataGenerator(m=0.6, sigma_b=4.5, sigma_e=1)
         train, test_known, test_new, train_cluster_ids, ptev, prev = dg.generate_split_samples([1, 3], [3, 2], [1, 1])
 
@@ -131,6 +133,15 @@ class MERFTest(unittest.TestCase):
         # Predict New Clusters
         yhat_new = m.predict(np.array(self.X_new), np.array(self.Z_new), self.clusters_new)
         self.assertEqual(len(yhat_new), 2)
+
+    def test_early_stopping(self):
+        np.random.seed(3187)
+        # Create a MERF model with a high early stopping threshold
+        m = MERF(max_iterations=10, gll_early_stop_threshold=0.1)
+        # Fit
+        m.fit(self.X_train, self.Z_train, self.clusters_train, self.y_train)
+        # The number of iterations should be less than max_iterations
+        self.assertTrue(len(m.gll_history) < 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implement early stopping for the MERF fitting procedure, based on relative tolerance. The default value has been changed to "None" to reflect that the option will be ignored unless specified.

Nothing sophisticated here; it checks if `abs((current_gll - last_gll) / last_gll)` is less than the threshold and, if so, breaks out of the loop. I also added one test.