### PR TITLE
Add Ability to Specify Additional Parameters to RandomForestRegressor

### DIFF
--- a/merf/merf.py
+++ b/merf/merf.py
@@ -31,9 +31,11 @@ class MERF(object):
 
         self.rf_opts = {} if rf_opts is None else rf_opts
 
-        rf_args = ['criterion', 'max_depth', 'min_samples_split', 'min_samples_leaf', 'min_weight_fraction_leaf',
-                   'max_features', 'max_leaf_nodes', 'min_impurity_decrease', 'min_impurity_split', 'bootstrap',
-                   'oob_score', 'n_jobs', 'random_state', 'verbose', 'warm_start', 'n_estimators']
+        rf_args = [
+            'criterion', 'max_depth', 'min_samples_split', 'min_samples_leaf', 'min_weight_fraction_leaf',
+            'max_features', 'max_leaf_nodes', 'min_impurity_decrease', 'min_impurity_split', 'bootstrap',
+            'oob_score', 'n_jobs', 'random_state', 'verbose', 'warm_start', 'n_estimators'
+        ]
         wrong_rf_args = set(self.rf_opts.keys()).difference(rf_args)
 
         if len(wrong_rf_args):

--- a/merf/tests.py
+++ b/merf/tests.py
@@ -132,6 +132,17 @@ class MERFTest(unittest.TestCase):
         yhat_new = m.predict(np.array(self.X_new), np.array(self.Z_new), self.clusters_new)
         self.assertEqual(len(yhat_new), 2)
 
+    def test_handle_wrong_rf_arg(self):
+        # Test for a TypeError when an argument to rf_opts is passed that is not applicable to RandomForestRegressor
+        with self.assertRaises(TypeError):
+            m = MERF(max_iterations=10, rf_opts={'wrong_arg': 99})
+
+    def test_handle_rf_args(self):
+        # Test that extra arguments to RandomForestRegressor are handled
+        m = MERF(max_iterations=10, rf_opts={'max_depth': 3, 'n_jobs': 1})
+        m.fit(self.X_train, self.Z_train, self.clusters_train, self.y_train)
+        self.assertTrue(m.trained_rf.get_params()['max_depth'] == 3 and m.trained_rf.get_params()['n_jobs'] == 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/merf/tests.py
+++ b/merf/tests.py
@@ -141,7 +141,10 @@ class MERFTest(unittest.TestCase):
         # Test that extra arguments to RandomForestRegressor are handled
         m = MERF(max_iterations=10, rf_opts={'max_depth': 3, 'n_jobs': 1})
         m.fit(self.X_train, self.Z_train, self.clusters_train, self.y_train)
-        self.assertTrue(m.trained_rf.get_params()['max_depth'] == 3 and m.trained_rf.get_params()['n_jobs'] == 1)
+        # Test for max depth
+        self.assertTrue(m.trained_rf.get_params()['max_depth'] == 3)
+        # Test for n_jobs
+        self.assertTrue(m.trained_rf.get_params()['n_jobs'] == 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add ability to specify additional parameters to RandomForestRegressor, with some minor error checking and two additional tests.

Options are passed in as dictionary argument `rf_opts`. `n_estimators` is ignored in favor of the argument to the constructor; `oob_score` is ignored and always set to True; `warm_start` is ignored (assumed to be False).

Two reasons this is helpful for me, at least: the random forest fit is often faster (particularly on my laptop) with `n_jobs` set to 1. I'm also hoping to investigate the shap interpretability package, but the underlying algorithms perform *extremely* poorly on deep trees, so the ability to specify `max_depth` would make that a bit easier.