### PR TITLE
Add options

### DIFF
--- a/merf/merf.py
+++ b/merf/merf.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class MERF(object):
-    def __init__(self, n_estimators=300, min_iterations=10, gll_early_stop_threshold=1e-4, max_iterations=20):
+    def __init__(self, n_estimators=300, min_iterations=10, gll_early_stop_threshold=None, max_iterations=20):
         self.n_estimators = n_estimators
         self.min_iterations = min_iterations
         self.gll_early_stop_threshold = gll_early_stop_threshold
@@ -124,7 +124,9 @@ class MERF(object):
         self.sigma2_hat_history.append(sigma2_hat)
         self.D_hat_history.append(D_hat)
 
-        while iteration < self.max_iterations:
+        stop_flag, iter_begun = False, False
+
+        while iteration < self.max_iterations and not stop_flag:
             iteration += 1
             logger.debug("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
             logger.debug("Iteration: {}".format(iteration))
@@ -241,6 +243,18 @@ class MERF(object):
 
             logger.info("GLL is {} at iteration {}.".format(gll, iteration))
             self.gll_history.append(gll)
+
+            if self.gll_early_stop_threshold is not None:
+                if not iter_begun:
+                    iter_begun = True
+                else:
+                    curr_threshold = np.abs((gll - self.gll_history[-2]) / self.gll_history[-2])
+                    logger.debug("stop threshold = {}".format(curr_threshold))
+
+                    if curr_threshold < self.gll_early_stop_threshold:
+                        logger.info("Gll {} less than threshold {}, stopping early ...".
+                                    format(gll, curr_threshold))
+                        stop_flag = True
 
         # Store off most recent random forest model and b_hat as the model to be used in the prediction stage
         self.cluster_counts = cluster_counts

--- a/merf/merf.py
+++ b/merf/merf.py
@@ -124,7 +124,8 @@ class MERF(object):
         self.sigma2_hat_history.append(sigma2_hat)
         self.D_hat_history.append(D_hat)
 
-        stop_flag, iter_begun = False, False
+        stop_flag = False
+        iter_begun = False
 
         while iteration < self.max_iterations and not stop_flag:
             iteration += 1
@@ -252,8 +253,7 @@ class MERF(object):
                     logger.debug("stop threshold = {}".format(curr_threshold))
 
                     if curr_threshold < self.gll_early_stop_threshold:
-                        logger.info("Gll {} less than threshold {}, stopping early ...".
-                                    format(gll, curr_threshold))
+                        logger.info("Gll {} less than threshold {}, stopping early ...".format(gll, curr_threshold))
                         stop_flag = True
 
         # Store off most recent random forest model and b_hat as the model to be used in the prediction stage

--- a/merf/merf.py
+++ b/merf/merf.py
@@ -31,9 +31,11 @@ class MERF(object):
 
         self.rf_opts = {} if rf_opts is None else rf_opts
 
-        rf_args = ['criterion', 'max_depth', 'min_samples_split', 'min_samples_leaf', 'min_weight_fraction_leaf',
-                   'max_features', 'max_leaf_nodes', 'min_impurity_decrease', 'min_impurity_split', 'bootstrap',
-                   'oob_score', 'n_jobs', 'random_state', 'verbose', 'warm_start', 'n_estimators']
+        rf_args = [
+            'criterion', 'max_depth', 'min_samples_split', 'min_samples_leaf', 'min_weight_fraction_leaf',
+            'max_features', 'max_leaf_nodes', 'min_impurity_decrease', 'min_impurity_split', 'bootstrap',
+            'oob_score', 'n_jobs', 'random_state', 'verbose', 'warm_start', 'n_estimators'
+        ]
         wrong_rf_args = set(self.rf_opts.keys()).difference(rf_args)
 
         if len(wrong_rf_args):

--- a/merf/tests.py
+++ b/merf/tests.py
@@ -132,6 +132,17 @@ class MERFTest(unittest.TestCase):
         yhat_new = m.predict(np.array(self.X_new), np.array(self.Z_new), self.clusters_new)
         self.assertEqual(len(yhat_new), 2)
 
+    def test_handle_wrong_rf_arg(self):
+        # Test for a TypeError when an argument to rf_opts is passed that is not applicable to RandomForestRegressor
+        with self.assertRaises(TypeError):
+            m = MERF(max_iterations=10, rf_opts={'wrong_arg': 99})
+
+    def test_handle_rf_args(self):
+        # Test that extra arguments to RandomForestRegressor are handled
+        m = MERF(max_iterations=10, rf_opts={'max_depth': 3, 'n_jobs': 1})
+        m.fit(self.X_train, self.Z_train, self.clusters_train, self.y_train)
+        self.assertTrue(m.trained_rf.get_params()['max_depth'] == 3 and m.trained_rf.get_params()['n_jobs'] == 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/merf/tests.py
+++ b/merf/tests.py
@@ -86,6 +86,8 @@ class DataGenerationTest(unittest.TestCase):
 
 class MERFTest(unittest.TestCase):
     def setUp(self):
+        np.random.seed(3187)
+
         dg = MERFDataGenerator(m=0.6, sigma_b=4.5, sigma_e=1)
         train, test_known, test_new, train_cluster_ids, ptev, prev = dg.generate_split_samples([1, 3], [3, 2], [1, 1])
 
@@ -131,6 +133,15 @@ class MERFTest(unittest.TestCase):
         # Predict New Clusters
         yhat_new = m.predict(np.array(self.X_new), np.array(self.Z_new), self.clusters_new)
         self.assertEqual(len(yhat_new), 2)
+
+    def test_early_stopping(self):
+        np.random.seed(3187)
+        # Create a MERF model with a high early stopping threshold
+        m = MERF(max_iterations=10, gll_early_stop_threshold=0.1)
+        # Fit
+        m.fit(self.X_train, self.Z_train, self.clusters_train, self.y_train)
+        # The number of iterations should be less than max_iterations
+        self.assertTrue(len(m.gll_history) < 10)
 
 
 if __name__ == "__main__":

--- a/merf/tests.py
+++ b/merf/tests.py
@@ -141,7 +141,10 @@ class MERFTest(unittest.TestCase):
         # Test that extra arguments to RandomForestRegressor are handled
         m = MERF(max_iterations=10, rf_opts={'max_depth': 3, 'n_jobs': 1})
         m.fit(self.X_train, self.Z_train, self.clusters_train, self.y_train)
-        self.assertTrue(m.trained_rf.get_params()['max_depth'] == 3 and m.trained_rf.get_params()['n_jobs'] == 1)
+        # Test for max depth
+        self.assertTrue(m.trained_rf.get_params()['max_depth'] == 3)
+        # Test for n_jobs
+        self.assertTrue(m.trained_rf.get_params()['n_jobs'] == 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add ability to specify additional parameters to RandomForestRegressor, with some minor error checking and two additional tests.

Options are passed in as dictionary argument rf_opts. n_estimators is ignored in favor of the argument to the constructor; oob_score is ignored and always set to True; warm_start is ignored (assumed to be False).

Two reasons this is helpful for me, at least: the random forest fit is often faster (particularly on my laptop) with n_jobs set to 1. I'm also hoping to investigate the shap interpretability package, but the underlying algorithms perform extremely poorly on deep trees, so the ability to specify max_depth would make that a bit easier.

This is a repeat of another pull request, closed by me, attempting to fix formatting issues that cause continuous integration to fail.