### PR TITLE
Random forest can now take user defined parameters.

### DIFF
--- a/merf/merf.py
+++ b/merf/merf.py
@@ -14,12 +14,16 @@ logger = logging.getLogger(__name__)
 
 
 class MERF(object):
-    def __init__(self, min_iterations=10, gll_early_stop_threshold=1e-4, max_iterations=20, rf_params=None):
+    def __init__(self, n_estimators=300, min_iterations=10,
+                 gll_early_stop_threshold=1e-4, max_iterations=20, rf_params=None):
         self.min_iterations = min_iterations
         self.gll_early_stop_threshold = gll_early_stop_threshold
         self.max_iterations = max_iterations
-        self.rf_params = {'n_estimators': 300} if rf_params is None else rf_params
+
+        self.rf_params = {'n_estimators': n_estimators} if rf_params is None else rf_params
         self.rf_params.update({'oob_score': True, 'n_jobs': -1})
+        if 'n_estimators' not in self.rf_params:
+            self.rf_params.update({'n_estimators': n_estimators})
 
         self.cluster_counts = None
         self.trained_rf = None

--- a/merf/merf.py
+++ b/merf/merf.py
@@ -14,11 +14,12 @@ logger = logging.getLogger(__name__)
 
 
 class MERF(object):
-    def __init__(self, n_estimators=300, min_iterations=10, gll_early_stop_threshold=1e-4, max_iterations=20):
-        self.n_estimators = n_estimators
+    def __init__(self, min_iterations=10, gll_early_stop_threshold=1e-4, max_iterations=20, rf_params=None):
         self.min_iterations = min_iterations
         self.gll_early_stop_threshold = gll_early_stop_threshold
         self.max_iterations = max_iterations
+        self.rf_params = {'n_estimators': 300} if rf_params is None else rf_params
+        self.rf_params.update({'oob_score': True, 'n_jobs': -1})
 
         self.cluster_counts = None
         self.trained_rf = None
@@ -150,7 +151,7 @@ class MERF(object):
             assert len(y_star.shape) == 1
 
             # Do the random forest regression with all the fixed effects features
-            rf = RandomForestRegressor(n_estimators=self.n_estimators, oob_score=True, n_jobs=-1)
+            rf = RandomForestRegressor(**self.rf_params)
             rf.fit(X, y_star)
             f_hat = rf.oob_prediction_
 


### PR DESCRIPTION
The current implementation of MERF only allows the user to set the number of trees in the random forest. This pull request allows the user to set any parameter they want but prevents them from changing important params like having the out of bag score on.

I hope you accept this it has been useful for me.