### PR TITLE
Add type hints, types in pydoc, and type check on clusters arg

### DIFF
--- a/merf/merf.py
+++ b/merf/merf.py
@@ -36,15 +36,18 @@ class MERF(object):
         self.D_hat_history = []
         self.gll_history = []
 
-    def predict(self, X, Z, clusters):
+    def predict(self, X: np.ndarray, Z: np.ndarray, clusters: pd.Series):
         """
         Predict using trained MERF.  For known clusters the trained random effect correction is applied. For unknown
         clusters the pure fixed effect (RF) estimate is used.
-        :param X: fixed effect covariates
-        :param Z: random effect covariates
-        :param clusters: cluster assignments for samples
+        :param X (np.ndarray): fixed effect covariates
+        :param Z (np.ndarray): random effect covariates
+        :param clusters (pd.Series): cluster assignments for samples
         :return: y_hat, i.e. predictions
         """
+        if type(clusters) != pd.Series:
+            raise TypeError("clusters must be a pandas Series.")
+
         if self.trained_rf is None:
             raise NotFittedError(
                 "This MERF instance is not fitted yet. Call 'fit' with appropriate arguments before "
@@ -72,15 +75,17 @@ class MERF(object):
 
         return y_hat
 
-    def fit(self, X, Z, clusters, y):
+    def fit(self, X: np.ndarray, Z: np.ndarray, clusters: pd.Series, y: np.ndarray):
         """
         Fit MERF using EM algorithm.
-        :param X: fixed effect covariates
-        :param Z: random effect covariates
-        :param clusters: cluster assignments for samples
-        :param y: response/target variable
+        :param X (np.ndarray): fixed effect covariates
+        :param Z (np.ndarray): random effect covariates
+        :param clusters (pd.Series): cluster assignments for samples
+        :param y (np.ndarray): response/target variable
         :return: fitted model
         """
+        if type(clusters) != pd.Series:
+            raise TypeError("clusters must be a pandas Series.")
 
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Input Checks ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         assert len(Z) == len(X)

--- a/merf/merf_test.py
+++ b/merf/merf_test.py
@@ -136,6 +136,17 @@ class MERFTest(unittest.TestCase):
         yhat_new = m.predict(np.array(self.X_new), np.array(self.Z_new), self.clusters_new)
         self.assertEqual(len(yhat_new), 2)
 
+    def test_type_error(self):
+        m = MERF(max_iterations=10)
+        self.assertRaises(
+            TypeError,
+            m.fit,
+            np.array(self.X_train),
+            np.array(self.Z_train),
+            np.array(self.clusters_train),
+            self.y_train,
+        )
+
     def test_early_stopping(self):
         np.random.seed(3187)
         # Create a MERF model with a high early stopping threshold


### PR DESCRIPTION
# Context

Adding type hinting, types in pydoc, and type checks on clusters argument. 

# Changes

* Type check on arguments to fit and predict.

# Behaves Differently

* Will exception out gracefully if wrong type is passed to fit and predict.

Closes #13 
